### PR TITLE
ZK Capped Minter Factory

### DIFF
--- a/l2-contracts/foundry.toml
+++ b/l2-contracts/foundry.toml
@@ -11,6 +11,7 @@
   ]
   solc_version = "0.8.24"
   verbosity = 3
+  fs_permissions = [{ access = "read", path = "./zkout" }]
 
 [profile.ci]
   fuzz = { runs = 5000 }

--- a/l2-contracts/script/DeployZkCappedMinterFactory.ts
+++ b/l2-contracts/script/DeployZkCappedMinterFactory.ts
@@ -1,0 +1,44 @@
+import { config as dotEnvConfig } from "dotenv";
+import { Deployer } from "@matterlabs/hardhat-zksync-deploy";
+import { Wallet } from "zksync-ethers";
+import * as hre from "hardhat";
+import * as fs from 'fs';
+import * as path from 'path';
+
+// Read the bytecode hash from ZkCappedMinter.json
+// Verify the zksolc version used to compile the contract, the hash changes with different versions
+const zkCappedMinterPath = path.join(__dirname, '../zkout/ZkCappedMinter.sol/ZkCappedMinter.json');
+const zkCappedMinterJson = JSON.parse(fs.readFileSync(zkCappedMinterPath, 'utf8'));
+const BYTECODE_HASH = '0x' + zkCappedMinterJson.hash;
+
+async function main() {
+  dotEnvConfig();
+
+  const deployerPrivateKey = process.env.DEPLOYER_PRIVATE_KEY;
+  if (!deployerPrivateKey) {
+    throw "Please set DEPLOYER_PRIVATE_KEY in your .env file";
+  }
+
+  const contractName = "ZkCappedMinterFactory";
+  console.log("Deploying " + contractName + "...");
+
+  const zkWallet = new Wallet(deployerPrivateKey);
+  const deployer = new Deployer(hre, zkWallet, 'create2');
+
+  const contract = await deployer.loadArtifact(contractName);
+  const constructorArgs = [BYTECODE_HASH];
+  const factory = await deployer.deploy(contract, constructorArgs);
+
+  console.log("constructor args: " + factory.interface.encodeDeploy(constructorArgs));
+
+  const contractAddress = await factory.getAddress();
+  console.log(`${contractName} was deployed to ${contractAddress}`);
+
+  const bytecodeHash = await factory.BYTECODE_HASH();
+  console.log(`The BYTECODE_HASH is set to: ${bytecodeHash}`);
+}
+
+main().catch((error) => {
+    console.error(error);
+    process.exitCode = 1;
+  });

--- a/l2-contracts/src/ZkCappedMinterFactory.sol
+++ b/l2-contracts/src/ZkCappedMinterFactory.sol
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.24;
+
+import {L2ContractHelper} from "src/lib/L2ContractHelper.sol";
+import {ZkCappedMinter} from "src/ZkCappedMinter.sol";
+import {IMintableAndDelegatable} from "src/interfaces/IMintableAndDelegatable.sol";
+
+/// @title ZkCappedMinterFactory
+/// @author [ScopeLift](https://scopelift.co)
+/// @notice Factory contract to deploy ZkCappedMinter contracts using CREATE2.
+contract ZkCappedMinterFactory {
+  /// @dev Bytecode hash should be updated with the correct value from ./zkout/ZkCappedMinter.sol/ZkCappedMinter.json.
+  bytes32 public immutable BYTECODE_HASH;
+
+  constructor(bytes32 _bytecodeHash) {
+    BYTECODE_HASH = _bytecodeHash;
+  }
+
+  /// @notice Emitted when a new ZkCappedMinter is created.
+  /// @param minterAddress The address of the newly deployed ZkCappedMinter.
+  /// @param token The token contract where tokens will be minted.
+  /// @param admin The address authorized to mint tokens.
+  /// @param cap The maximum number of tokens that may be minted.
+  event CappedMinterCreated(address indexed minterAddress, IMintableAndDelegatable token, address admin, uint256 cap);
+
+  /// @notice Deploys a new ZkCappedMinter contract using CREATE2.
+  /// @param _token The token contract where tokens will be minted.
+  /// @param _admin The address authorized to mint tokens.
+  /// @param _cap The maximum number of tokens that may be minted.
+  /// @param _saltNonce A user-provided nonce for salt calculation.
+  /// @return minterAddress The address of the newly deployed ZkCappedMinter.
+  function createCappedMinter(IMintableAndDelegatable _token, address _admin, uint256 _cap, uint256 _saltNonce)
+    external
+    returns (address minterAddress)
+  {
+    bytes memory saltArgs = abi.encode(_token, _admin, _cap);
+    bytes32 salt = _calculateSalt(saltArgs, _saltNonce);
+    ZkCappedMinter instance = new ZkCappedMinter{salt: salt}(_token, _admin, _cap);
+    minterAddress = address(instance);
+
+    emit CappedMinterCreated(minterAddress, _token, _admin, _cap);
+  }
+
+  /// @notice Computes the address of a ZkCappedMinter deployed via this factory.
+  /// @param _token The token contract where tokens will be minted.
+  /// @param _admin The address authorized to mint tokens.
+  /// @param _cap The maximum number of tokens that may be minted.
+  /// @param _saltNonce The nonce used for salt calculation.
+  /// @return addr The address of the ZkCappedMinter.
+  function getMinter(IMintableAndDelegatable _token, address _admin, uint256 _cap, uint256 _saltNonce)
+    external
+    view
+    returns (address addr)
+  {
+    bytes memory saltArgs = abi.encode(_token, _admin, _cap);
+    bytes32 salt = _calculateSalt(saltArgs, _saltNonce);
+    addr = L2ContractHelper.computeCreate2Address(
+      address(this), salt, BYTECODE_HASH, keccak256(abi.encode(_token, _admin, _cap))
+    );
+  }
+
+  /// @notice Calculates the salt for CREATE2 deployment.
+  /// @param _args The encoded arguments for the salt calculation.
+  /// @param _saltNonce A user-provided nonce for additional uniqueness.
+  /// @return The calculated salt as a bytes32 value.
+  function _calculateSalt(bytes memory _args, uint256 _saltNonce) internal view returns (bytes32) {
+    return keccak256(abi.encode(_args, block.chainid, _saltNonce));
+  }
+}

--- a/l2-contracts/src/lib/L2ContractHelper.sol
+++ b/l2-contracts/src/lib/L2ContractHelper.sol
@@ -1,0 +1,165 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.19;
+
+/**
+ * @author Matter Labs
+ * @custom:security-contact security@matterlabs.dev
+ * @notice Smart contract for sending arbitrary length messages to L1
+ * @dev by default ZkSync can send fixed-length messages on L1.
+ * A fixed length message has 4 parameters `senderAddress`, `isService`, `key`, `value`,
+ * the first one is taken from the context, the other three are chosen by the sender.
+ * @dev To send a variable-length message we use this trick:
+ * - This system contract accepts an arbitrary length message and sends a fixed length message with
+ * parameters `senderAddress == this`, `isService == true`, `key == msg.sender`, `value == keccak256(message)`.
+ * - The contract on L1 accepts all sent messages and if the message came from this system contract
+ * it requires that the preimage of `value` be provided.
+ * @dev This was sourced from the matter-labs/era-contracts repo linked below.
+ * https://github.com/matter-labs/era-contracts/blob/main/l2-contracts/contracts/L2ContractHelper.sol
+ */
+interface IL2Messenger {
+  /// @notice Sends an arbitrary length message to L1.
+  /// @param _message The variable length message to be sent to L1.
+  /// @return Returns the keccak256 hashed value of the message.
+  function sendToL1(bytes memory _message) external returns (bytes32);
+}
+
+/**
+ * @author Matter Labs
+ * @custom:security-contact security@matterlabs.dev
+ * @notice Interface for the contract that is used to deploy contracts on L2.
+ */
+interface IContractDeployer {
+  /// @notice A struct that describes a forced deployment on an address.
+  /// @param bytecodeHash The bytecode hash to put on an address.
+  /// @param newAddress The address on which to deploy the bytecodehash to.
+  /// @param callConstructor Whether to run the constructor on the force deployment.
+  /// @param value The `msg.value` with which to initialize a contract.
+  /// @param input The constructor calldata.
+  struct ForceDeployment {
+    bytes32 bytecodeHash;
+    address newAddress;
+    bool callConstructor;
+    uint256 value;
+    bytes input;
+  }
+
+  /// @notice This method is to be used only during an upgrade to set bytecodes on specific addresses.
+  /// @param _deployParams A set of parameters describing force deployment.
+  function forceDeployOnAddresses(ForceDeployment[] calldata _deployParams) external payable;
+
+  /// @notice Creates a new contract at a determined address using the `CREATE2` salt on L2
+  /// @param _salt a unique value to create the deterministic address of the new contract
+  /// @param _bytecodeHash the bytecodehash of the new contract to be deployed
+  /// @param _input the calldata to be sent to the constructor of the new contract
+  function create2(bytes32 _salt, bytes32 _bytecodeHash, bytes calldata _input) external returns (address);
+}
+
+/**
+ * @author Matter Labs
+ * @custom:security-contact security@matterlabs.dev
+ * @notice Interface for the contract that is used to simulate ETH on L2.
+ */
+interface IBaseToken {
+  /// @notice Allows the withdrawal of ETH to a given L1 receiver along with an additional message.
+  /// @param _l1Receiver The address on L1 to receive the withdrawn ETH.
+  /// @param _additionalData Additional message or data to be sent alongside the withdrawal.
+  function withdrawWithMessage(address _l1Receiver, bytes memory _additionalData) external payable;
+}
+
+uint160 constant SYSTEM_CONTRACTS_OFFSET = 0x8000; // 2^15
+
+address constant BOOTLOADER_ADDRESS = address(SYSTEM_CONTRACTS_OFFSET + 0x01);
+address constant MSG_VALUE_SYSTEM_CONTRACT = address(SYSTEM_CONTRACTS_OFFSET + 0x09);
+address constant DEPLOYER_SYSTEM_CONTRACT = address(SYSTEM_CONTRACTS_OFFSET + 0x06);
+
+IL2Messenger constant L2_MESSENGER = IL2Messenger(address(SYSTEM_CONTRACTS_OFFSET + 0x08));
+
+IBaseToken constant L2_BASE_TOKEN_ADDRESS = IBaseToken(address(SYSTEM_CONTRACTS_OFFSET + 0x0a));
+
+/**
+ * @author Matter Labs
+ * @custom:security-contact security@matterlabs.dev
+ * @notice Helper library for working with L2 contracts on L1.
+ */
+library L2ContractHelper {
+  /// @dev The prefix used to create CREATE2 addresses.
+  bytes32 private constant CREATE2_PREFIX = keccak256("zksyncCreate2");
+
+  /// @notice Sends L2 -> L1 arbitrary-long message through the system contract messenger.
+  /// @param _message Data to be sent to L1.
+  /// @return keccak256 hash of the sent message.
+  function sendMessageToL1(bytes memory _message) internal returns (bytes32) {
+    return L2_MESSENGER.sendToL1(_message);
+  }
+
+  /// @notice Computes the create2 address for a Layer 2 contract.
+  /// @param _sender The address of the contract creator.
+  /// @param _salt The salt value to use in the create2 address computation.
+  /// @param _bytecodeHash The contract bytecode hash.
+  /// @param _constructorInputHash The keccak256 hash of the constructor input data.
+  /// @return The create2 address of the contract.
+  /// NOTE: L2 create2 derivation is different from L1 derivation!
+  function computeCreate2Address(address _sender, bytes32 _salt, bytes32 _bytecodeHash, bytes32 _constructorInputHash)
+    internal
+    pure
+    returns (address)
+  {
+    bytes32 senderBytes = bytes32(uint256(uint160(_sender)));
+    bytes32 data = keccak256(
+      // solhint-disable-next-line func-named-parameters
+      bytes.concat(CREATE2_PREFIX, senderBytes, _salt, _bytecodeHash, _constructorInputHash)
+    );
+
+    return address(uint160(uint256(data)));
+  }
+}
+
+/// @notice Structure used to represent a zkSync transaction.
+struct Transaction {
+  // The type of the transaction.
+  uint256 txType;
+  // The caller.
+  uint256 from;
+  // The callee.
+  uint256 to;
+  // The gasLimit to pass with the transaction.
+  // It has the same meaning as Ethereum's gasLimit.
+  uint256 gasLimit;
+  // The maximum amount of gas the user is willing to pay for a byte of pubdata.
+  uint256 gasPerPubdataByteLimit;
+  // The maximum fee per gas that the user is willing to pay.
+  // It is akin to EIP1559's maxFeePerGas.
+  uint256 maxFeePerGas;
+  // The maximum priority fee per gas that the user is willing to pay.
+  // It is akin to EIP1559's maxPriorityFeePerGas.
+  uint256 maxPriorityFeePerGas;
+  // The transaction's paymaster. If there is no paymaster, it is equal to 0.
+  uint256 paymaster;
+  // The nonce of the transaction.
+  uint256 nonce;
+  // The value to pass with the transaction.
+  uint256 value;
+  // In the future, we might want to add some
+  // new fields to the struct. The `txData` struct
+  // is to be passed to account and any changes to its structure
+  // would mean a breaking change to these accounts. In order to prevent this,
+  // we should keep some fields as "reserved".
+  // It is also recommended that their length is fixed, since
+  // it would allow easier proof integration (in case we will need
+  // some special circuit for preprocessing transactions).
+  uint256[4] reserved;
+  // The transaction's calldata.
+  bytes data;
+  // The signature of the transaction.
+  bytes signature;
+  // The properly formatted hashes of bytecodes that must be published on L1
+  // with the inclusion of this transaction. Note, that a bytecode has been published
+  // before, the user won't pay fees for its republishing.
+  bytes32[] factoryDeps;
+  // The input to the paymaster.
+  bytes paymasterInput;
+  // Reserved dynamic type for the future use-case. Using it should be avoided,
+  // But it is still here, just in case we want to enable some additional functionality.
+  bytes reservedDynamic;
+}

--- a/l2-contracts/test/ZkCappedMinterFactory.t.sol
+++ b/l2-contracts/test/ZkCappedMinterFactory.t.sol
@@ -1,0 +1,115 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.24;
+
+import {ZkTokenTest} from "test/utils/ZkTokenTest.sol";
+import {ZkCappedMinterFactory} from "src/ZkCappedMinterFactory.sol";
+import {ZkCappedMinter} from "src/ZkCappedMinter.sol";
+import {IMintableAndDelegatable} from "src/interfaces/IMintableAndDelegatable.sol";
+import {Create2} from "@openzeppelin/contracts/utils/Create2.sol";
+import {console2} from "forge-std/console2.sol";
+import {stdJson} from "forge-std/StdJson.sol";
+
+contract ZkCappedMinterFactoryTest is ZkTokenTest {
+  bytes32 bytecodeHash;
+  ZkCappedMinterFactory factory;
+
+  function setUp() public virtual override {
+    super.setUp();
+    
+    // Read the bytecode hash from the JSON file
+    string memory root = vm.projectRoot();
+    string memory path = string.concat(root, "/zkout/ZkCappedMinter.sol/ZkCappedMinter.json");
+    string memory json = vm.readFile(path);
+    bytecodeHash = bytes32(stdJson.readBytes(json, ".hash"));
+
+    factory = new ZkCappedMinterFactory(bytecodeHash);
+  }
+
+  function _assumeValidAddress(address _addr) internal view {
+    vm.assume(_addr != address(0) && _addr != address(factory));
+  }
+
+  function _boundToReasonableCap(uint256 _cap) internal view returns (uint256) {
+    return bound(_cap, 1, MAX_MINT_SUPPLY);
+  }
+}
+
+contract CreateCappedMinter is ZkCappedMinterFactoryTest {
+  function testFuzz_CreatesNewCappedMinter(address _cappedMinterAdmin, uint256 _cap, uint256 _saltNonce) public {
+    _assumeValidAddress(_cappedMinterAdmin);
+    _cap = _boundToReasonableCap(_cap);
+
+    address minterAddress =
+      factory.createCappedMinter(IMintableAndDelegatable(address(token)), _cappedMinterAdmin, _cap, _saltNonce);
+
+    ZkCappedMinter minter = ZkCappedMinter(minterAddress);
+    assertEq(address(minter.TOKEN()), address(token));
+    assertEq(minter.ADMIN(), _cappedMinterAdmin);
+    assertEq(minter.CAP(), _cap);
+  }
+
+  function testFuzz_EmitsCappedMinterCreatedEvent(address _cappedMinterAdmin, uint256 _cap, uint256 _saltNonce) public {
+    _assumeValidAddress(_cappedMinterAdmin);
+    _cap = _boundToReasonableCap(_cap);
+
+    vm.expectEmit();
+    emit ZkCappedMinterFactory.CappedMinterCreated(
+      factory.getMinter(IMintableAndDelegatable(address(token)), _cappedMinterAdmin, _cap, _saltNonce),
+      IMintableAndDelegatable(address(token)),
+      _cappedMinterAdmin,
+      _cap
+    );
+
+    factory.createCappedMinter(IMintableAndDelegatable(address(token)), _cappedMinterAdmin, _cap, _saltNonce);
+  }
+
+  function testFuzz_RevertIf_CreatingDuplicateMinter(address _cappedMinterAdmin, uint256 _cap, uint256 _saltNonce)
+    public
+  {
+    _assumeValidAddress(_cappedMinterAdmin);
+    _cap = _boundToReasonableCap(_cap);
+
+    factory.createCappedMinter(IMintableAndDelegatable(address(token)), _cappedMinterAdmin, _cap, _saltNonce);
+
+    vm.expectRevert("Code hash is non-zero");
+    factory.createCappedMinter(IMintableAndDelegatable(address(token)), _cappedMinterAdmin, _cap, _saltNonce);
+  }
+}
+
+contract GetMinter is ZkCappedMinterFactoryTest {
+  function testFuzz_ReturnsCorrectMinterAddress(address _cappedMinterAdmin, uint256 _cap, uint256 _saltNonce) public {
+    _assumeValidAddress(_cappedMinterAdmin);
+    _cap = _boundToReasonableCap(_cap);
+
+    address expectedMinterAddress =
+      factory.getMinter(IMintableAndDelegatable(address(token)), _cappedMinterAdmin, _cap, _saltNonce);
+
+    address minterAddress =
+      factory.createCappedMinter(IMintableAndDelegatable(address(token)), _cappedMinterAdmin, _cap, _saltNonce);
+
+    assertEq(minterAddress, expectedMinterAddress);
+  }
+
+  function testFuzz_GetMinterWithoutDeployment(address _cappedMinterAdmin, uint256 _cap, uint256 _saltNonce) public {
+    _assumeValidAddress(_cappedMinterAdmin);
+    _cap = _boundToReasonableCap(_cap);
+
+    address expectedMinterAddress =
+      factory.getMinter(IMintableAndDelegatable(address(token)), _cappedMinterAdmin, _cap, _saltNonce);
+
+    uint256 codeSize;
+    assembly {
+      codeSize := extcodesize(expectedMinterAddress)
+    }
+    assertEq(codeSize, 0);
+
+    address minterAddress =
+      factory.createCappedMinter(IMintableAndDelegatable(address(token)), _cappedMinterAdmin, _cap, _saltNonce);
+
+    assembly {
+      codeSize := extcodesize(expectedMinterAddress)
+    }
+    assertGt(codeSize, 0);
+    assertEq(minterAddress, expectedMinterAddress);
+  }
+}


### PR DESCRIPTION
Resolves: #11

Adds the `ZkCappedMinterFactory` contract to deploy `ZkCappedMinter` contracts using CREATE2. It includes a `createCappedMinter` function that emits a `CappedMinterCreated` event with the new minter's address and parameters, a `getMinter` function to verify the deployment address of a capped minter created by this factory, and a Hardhat deploy script.
