### PR TITLE
More flexible governance upgrade

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -19,6 +19,3 @@
 [submodule "l2-contracts/lib/flexible-voting"]
 	path = l2-contracts/lib/flexible-voting
 	url = https://github.com/ScopeLift/flexible-voting
-[submodule "l1-contracts/lib/openzeppelin-contracts-upgradeable"]
-	path = l1-contracts/lib/openzeppelin-contracts-upgradeable
-	url = https://github.com/Openzeppelin/openzeppelin-contracts-upgradeable

--- a/.gitmodules
+++ b/.gitmodules
@@ -19,3 +19,6 @@
 [submodule "l2-contracts/lib/flexible-voting"]
 	path = l2-contracts/lib/flexible-voting
 	url = https://github.com/ScopeLift/flexible-voting
+[submodule "l1-contracts/lib/openzeppelin-contracts-upgradeable"]
+	path = l1-contracts/lib/openzeppelin-contracts-upgradeable
+	url = https://github.com/Openzeppelin/openzeppelin-contracts-upgradeable

--- a/.gitmodules
+++ b/.gitmodules
@@ -19,3 +19,6 @@
 [submodule "l2-contracts/lib/flexible-voting"]
 	path = l2-contracts/lib/flexible-voting
 	url = https://github.com/ScopeLift/flexible-voting
+[submodule "l1-contracts/lib/openzeppelin-contracts-upgradeable"]
+	path = l1-contracts/lib/openzeppelin-contracts-upgradeable
+	url = https://github.com/OpenZeppelin/openzeppelin-contracts-upgradeable

--- a/l1-contracts/scripts/MainnetRedeploy.s.sol
+++ b/l1-contracts/scripts/MainnetRedeploy.s.sol
@@ -13,11 +13,7 @@ contract MainnetRedeploy is Redeploy {
     function run() external {
         runRedeploy(
             0x8f7a9912416e8AdC4D9c21FAe1415D3318A11897, 
-            0x32400084C286CF3E17e7B677ea9583e60a000324, 
-            0xc2eE6b6af7d616f6e27ce7F4A451Aedc2b0F5f5C, 
-            0x303a465B659cBB0ab36eE643eA362c509EEb5213, 
-            0xD7f9f54194C633F36CCD5F3da84ad4a1c38cB2cB, 
-            type(ProtocolUpgradeHandler).creationCode
+            false
         );
     }
 }

--- a/l1-contracts/scripts/MainnetRedeploy.s.sol
+++ b/l1-contracts/scripts/MainnetRedeploy.s.sol
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.8.24;
+
+import "forge-std/Script.sol";
+import {Vm, console2} from "forge-std/Test.sol";
+
+import {Redeploy} from "./Redeploy.s.sol";
+
+import {ProtocolUpgradeHandler} from "../src/ProtocolUpgradeHandler.sol";
+
+contract MainnetRedeploy is Redeploy {
+    function run() external {
+        runRedeploy(
+            0x8f7a9912416e8adc4d9c21fae1415d3318a11897, 
+            0x32400084c286cf3e17e7b677ea9583e60a000324, 
+            0xc2eE6b6af7d616f6e27ce7F4A451Aedc2b0F5f5C, 
+            0x303a465B659cBB0ab36eE643eA362c509EEb5213, 
+            0xD7f9f54194C633F36CCD5F3da84ad4a1c38cB2cB, 
+            type(ProtocolUpgradeHandler).creationCode
+        );
+    }
+}

--- a/l1-contracts/scripts/MainnetRedeploy.s.sol
+++ b/l1-contracts/scripts/MainnetRedeploy.s.sol
@@ -12,8 +12,8 @@ import {ProtocolUpgradeHandler} from "../src/ProtocolUpgradeHandler.sol";
 contract MainnetRedeploy is Redeploy {
     function run() external {
         runRedeploy(
-            0x8f7a9912416e8adc4d9c21fae1415d3318a11897, 
-            0x32400084c286cf3e17e7b677ea9583e60a000324, 
+            0x8f7a9912416e8AdC4D9c21FAe1415D3318A11897, 
+            0x32400084C286CF3E17e7B677ea9583e60a000324, 
             0xc2eE6b6af7d616f6e27ce7F4A451Aedc2b0F5f5C, 
             0x303a465B659cBB0ab36eE643eA362c509EEb5213, 
             0xD7f9f54194C633F36CCD5F3da84ad4a1c38cB2cB, 

--- a/l1-contracts/scripts/Redeploy.s.sol
+++ b/l1-contracts/scripts/Redeploy.s.sol
@@ -119,7 +119,7 @@ contract Redeploy is Script {
         {
             bytes memory protocolUpgradeHandlerConstructorArgs = abi.encode(addresses.securityCouncil, addresses.guardians, addresses.emergencyUpgradeBoard, l2ProtocolGovernor, info.zksyncEra, info.stateTransitionManager, info.bridgehub, info.sharedBridge);
             bytes memory protocolUpgradeHandlerBytecode;
-            if (!_useTestnetUpgradeHandler) {
+            if (_useTestnetUpgradeHandler) {
                 protocolUpgradeHandlerBytecode = type(TestnetProtocolUpgradeHandler).creationCode;
             } else {
                 protocolUpgradeHandlerBytecode = type(ProtocolUpgradeHandler).creationCode;

--- a/l1-contracts/scripts/Redeploy.s.sol
+++ b/l1-contracts/scripts/Redeploy.s.sol
@@ -117,7 +117,7 @@ contract Redeploy is Script {
 
         // Firstly, we deploy the implementation
         {
-            bytes memory protocolUpgradeHandlerConstructorArgs = abi.encode(addresses.securityCouncil, addresses.guardians, addresses.emergencyUpgradeBoard, l2ProtocolGovernor, info.zksyncEra, info.stateTransitionManager, info.bridgehub, info.sharedBridge);
+            bytes memory protocolUpgradeHandlerConstructorArgs = abi.encode(l2ProtocolGovernor, info.zksyncEra, info.stateTransitionManager, info.bridgehub, info.sharedBridge);
             bytes memory protocolUpgradeHandlerBytecode;
             if (_useTestnetUpgradeHandler) {
                 protocolUpgradeHandlerBytecode = type(TestnetProtocolUpgradeHandler).creationCode;

--- a/l1-contracts/scripts/Redeploy.s.sol
+++ b/l1-contracts/scripts/Redeploy.s.sol
@@ -1,0 +1,162 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.8.24;
+
+import "forge-std/Script.sol";
+import {Vm, console2} from "forge-std/Test.sol";
+
+import "./Utils.sol";
+import "./ISafeSetup.sol";
+import "./IGnosisSafeProxyFactory.sol";
+import "./ICREATE3Factory.sol";
+
+import "../src/SecurityCouncil.sol";
+import "../src/Guardians.sol";
+import "../src/EmergencyUpgradeBoard.sol";
+import "../src/Multisig.sol";
+import {ProxyAdmin} from "@openzeppelin/contracts/proxy/transparent/ProxyAdmin.sol";
+import {TransparentUpgradeableProxy} from "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
+import {ProtocolUpgradeHandler} from "../src/ProtocolUpgradeHandler.sol"; 
+
+// A common redeploy script that can be used for both mainnet and testnet scripts
+contract Redeploy is Script {
+    ICREATE3Factory constant CREATE3_FACTORY = ICREATE3Factory(0x9fBB3DF7C40Da2e5A0dE984fFE2CCB7C47cd0ABf);
+
+    bytes32 PROTOCOL_UPGRADE_HANDLER_PROXY_SALT = keccak256("ProtocolUpgradeHandlerProxy"); 
+    bytes32 PROTOCOL_UPGRADE_HANDLER_IMPL_SALT = keccak256("ProtocolUpgradeHandlerImpl");
+    bytes32 GUARDIANS_SALT = keccak256("Guardians");
+    bytes32 SECURITY_COUNCIL_SALT = keccak256("SecurityCouncil");
+    bytes32 EMERGENCY_UPGRADE_BOARD_SALT = keccak256("EmergencyUpgradeBoard");
+
+    struct CurrentSystemParams {
+        address[] securityCouncilMembers;
+        address[] guardiansMembers;
+        address zkFoundationSafe;
+    }
+
+    function readMembers(address _multisig) internal view returns (address[] memory members) {
+        uint256 totalMembers = uint256(vm.load(_multisig, 0));
+        members = new address[](totalMembers);
+
+        for(uint256  i = 0; i < totalMembers; i++) {
+            members[i] = Multisig(_multisig).members(i);
+            require(members[i] != address(0), "Can not have empty members");
+        }
+
+        try Multisig(_multisig).members(totalMembers) returns (address addr) {
+            revert("Wrong number of members");
+        }
+        catch {
+            // It is expected to revert since the number of members is incorrect
+        }
+    }
+
+    function extractDataFromProtocolUpgradeHandler(ProtocolUpgradeHandler _currentProtocolUpgradeHandler) internal view returns (CurrentSystemParams memory) {
+        address securityCouncil = _currentProtocolUpgradeHandler.securityCouncil();
+        address guardians = _currentProtocolUpgradeHandler.guardians();
+        EmergencyUpgradeBoard emergencyUpgradeBoard = EmergencyUpgradeBoard(_currentProtocolUpgradeHandler.emergencyUpgradeBoard());
+
+        // A small cross check for consistency
+        require(emergencyUpgradeBoard.SECURITY_COUNCIL() == securityCouncil, "incorrect security council");
+        require(emergencyUpgradeBoard.GUARDIANS() == guardians, "incorrect guardians");
+        require(emergencyUpgradeBoard.PROTOCOL_UPGRADE_HANDLER() == IProtocolUpgradeHandler(address(_currentProtocolUpgradeHandler)), "incorrect protocol upgrade handler");
+
+        return CurrentSystemParams({
+            securityCouncilMembers: readMembers(securityCouncil),
+            guardiansMembers: readMembers(guardians),
+            zkFoundationSafe: emergencyUpgradeBoard.ZK_FOUNDATION_SAFE()
+        });
+    }
+
+    function runRedeploy(
+        address _currentHandler,
+        address _zkSyncEra,
+        address _stateTransitionManagerAddr,
+        address _bridgehub,
+        address _sharedBridge,
+        bytes memory _protocolUpgradeHandlerBytecode
+    ) public {
+        // To ensure that all the data is the same as before, we fetch what it is now
+        // and then we will use it to deploy our contracts.
+        CurrentSystemParams memory info = extractDataFromProtocolUpgradeHandler(ProtocolUpgradeHandler(payable(_currentHandler)));
+        
+        uint256 deployerPrivateKey = vm.envUint("PRIVATE_KEY");
+        Vm.Wallet memory deployerWallet = vm.createWallet(deployerPrivateKey);
+
+        DeployedContracts memory addresses = predictAddresses(deployerWallet.addr);
+
+        address l2ProtocolGovernor = vm.envAddress("L2_PROTOCOL_GOVERNOR");
+
+        // Firstly, we deploy the implementation
+        {
+            bytes memory protocolUpgradeHandlerConstructorArgs = abi.encode(addresses.securityCouncil, addresses.guardians, addresses.emergencyUpgradeBoard, l2ProtocolGovernor, _zkSyncEra, _stateTransitionManagerAddr, _bridgehub, _sharedBridge);
+            bytes memory protocolUpgradeHandlerCreationCode = abi.encodePacked(_protocolUpgradeHandlerBytecode, protocolUpgradeHandlerConstructorArgs);
+            vm.startBroadcast();
+            CREATE3_FACTORY.deploy(PROTOCOL_UPGRADE_HANDLER_IMPL_SALT, protocolUpgradeHandlerCreationCode);
+            vm.stopBroadcast();
+        }
+
+        // Now, we can deploy the proxy.
+        {
+            // Note, that the proxy is itself the owner. The calls to the proxy impl will still be allowed, since
+            // the TransparentUpgradeableProxy automatically creates a ProxyAdmin instance. 
+            bytes memory initdata = abi.encodeCall(ProtocolUpgradeHandler.initialize, (addresses.securityCouncil, addresses.guardians, addresses.emergencyUpgradeBoard));
+            bytes memory proxyConstructorArgs = abi.encode(addresses.protocolUpgradeHandlerImpl, addresses.protocolUpgradeHandlerProxy, initdata);
+            bytes memory proxyCreationCode = abi.encodePacked(type(TransparentUpgradeableProxy).creationCode, proxyConstructorArgs);
+
+            vm.startBroadcast();
+            CREATE3_FACTORY.deploy(PROTOCOL_UPGRADE_HANDLER_PROXY_SALT, proxyCreationCode);
+            vm.stopBroadcast();
+        }
+        
+        // Deploying guardians
+        {
+            bytes memory guardiansConstructorArgs = abi.encode(addresses.protocolUpgradeHandlerProxy, _zkSyncEra, info.guardiansMembers);
+            bytes memory guardiansCreationCode = abi.encodePacked(type(Guardians).creationCode, guardiansConstructorArgs);   
+            vm.startBroadcast();
+            CREATE3_FACTORY.deploy(GUARDIANS_SALT, guardiansCreationCode);
+            vm.stopBroadcast();
+        }
+
+        // Deploying security council
+        {
+            bytes memory securityCouncilConstructorArgs = abi.encode(addresses.protocolUpgradeHandlerProxy, info.securityCouncilMembers);
+            bytes memory securityCouncilCreationCode = abi.encodePacked(type(SecurityCouncil).creationCode, securityCouncilConstructorArgs);
+            
+            vm.startBroadcast();
+            CREATE3_FACTORY.deploy(SECURITY_COUNCIL_SALT, securityCouncilCreationCode);
+            vm.stopBroadcast();   
+        }
+
+        // Deploying emergency upgrade board
+        {
+            bytes memory emergencyUpgradeBoardConstructorArgs = abi.encode(addresses.protocolUpgradeHandlerProxy, addresses.securityCouncil, addresses.guardians, info.zkFoundationSafe);
+            bytes memory emergencyUpgradeBoardCreationCode = abi.encodePacked(type(EmergencyUpgradeBoard).creationCode, emergencyUpgradeBoardConstructorArgs);
+            
+            vm.startBroadcast();
+            CREATE3_FACTORY.deploy(EMERGENCY_UPGRADE_BOARD_SALT, emergencyUpgradeBoardCreationCode);
+            vm.stopBroadcast();
+        }
+    }
+
+    struct DeployedContracts {
+        address protocolUpgradeHandlerImpl;
+        address protocolUpgradeHandlerProxy;
+        address guardians;
+        address securityCouncil;
+        address emergencyUpgradeBoard;
+    }
+
+    function predictAddresses(address deployerWallet) public returns(DeployedContracts memory deployedContracts) {
+        deployedContracts.protocolUpgradeHandlerImpl = CREATE3_FACTORY.getDeployed(deployerWallet, PROTOCOL_UPGRADE_HANDLER_IMPL_SALT);
+        console2.log("Protocol Upgrade Handler impl address: ", deployedContracts.protocolUpgradeHandlerImpl);
+        deployedContracts.protocolUpgradeHandlerProxy = CREATE3_FACTORY.getDeployed(deployerWallet, PROTOCOL_UPGRADE_HANDLER_PROXY_SALT);
+        console2.log("Protocol Upgrade Handler proxy address: ", deployedContracts.protocolUpgradeHandlerProxy);
+        deployedContracts.guardians = CREATE3_FACTORY.getDeployed(deployerWallet, GUARDIANS_SALT);
+        console2.log("Guardians address: ", deployedContracts.guardians);
+        deployedContracts.securityCouncil = CREATE3_FACTORY.getDeployed(deployerWallet, SECURITY_COUNCIL_SALT);
+        console2.log("Security Council address: ", deployedContracts.securityCouncil);
+        deployedContracts.emergencyUpgradeBoard = CREATE3_FACTORY.getDeployed(deployerWallet, EMERGENCY_UPGRADE_BOARD_SALT);
+        console2.log("Emergency Upgrade Board address: ", deployedContracts.emergencyUpgradeBoard);
+    }
+}

--- a/l1-contracts/scripts/TestnetRedeploy.s.sol
+++ b/l1-contracts/scripts/TestnetRedeploy.s.sol
@@ -13,11 +13,7 @@ contract TestnetRedeploy is Redeploy {
     function run() external {
         runRedeploy(
             0x9B956d242e6806044877C7C1B530D475E371d544, 
-            0x9A6DE0f62Aa270A8bCB1e2610078650D539B1Ef9, 
-            0x4e39E90746A9ee410A8Ce173C7B96D3AfEd444a5, 
-            0x35A54c8C757806eB6820629bc82d90E056394C92, 
-            0x3E8b2fe58675126ed30d0d12dea2A9bda72D18Ae, 
-            type(TestnetProtocolUpgradeHandler).creationCode
+            true
         );
     }
 }

--- a/l1-contracts/scripts/TestnetRedeploy.s.sol
+++ b/l1-contracts/scripts/TestnetRedeploy.s.sol
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.8.24;
+
+import "forge-std/Script.sol";
+import {Vm, console2} from "forge-std/Test.sol";
+
+import {Redeploy} from "./Redeploy.s.sol";
+
+import {TestnetProtocolUpgradeHandler} from "../src/TestnetProtocolUpgradeHandler.sol";
+
+contract TestnetRedeploy is Redeploy {
+    function run() external {
+        runRedeploy(
+            0x9B956d242e6806044877C7C1B530D475E371d544, 
+            0x9A6DE0f62Aa270A8bCB1e2610078650D539B1Ef9, 
+            0x4e39E90746A9ee410A8Ce173C7B96D3AfEd444a5, 
+            0x35A54c8C757806eB6820629bc82d90E056394C92, 
+            0x3E8b2fe58675126ed30d0d12dea2A9bda72D18Ae, 
+            type(TestnetProtocolUpgradeHandler).creationCode
+        );
+    }
+}

--- a/l1-contracts/src/ProtocolUpgradeHandler.sol
+++ b/l1-contracts/src/ProtocolUpgradeHandler.sol
@@ -490,6 +490,5 @@ contract ProtocolUpgradeHandler is IProtocolUpgradeHandler, Initializable {
 
         emergencyUpgradeBoard = _emergencyUpgradeBoard;
         emit ChangeEmergencyUpgradeBoard(address(0), _emergencyUpgradeBoard);
-
     }
 }

--- a/l1-contracts/src/ProtocolUpgradeHandler.sol
+++ b/l1-contracts/src/ProtocolUpgradeHandler.sol
@@ -6,6 +6,7 @@ import {IZKsyncEra} from "./interfaces/IZKsyncEra.sol";
 import {IStateTransitionManager} from "./interfaces/IStateTransitionManager.sol";
 import {IPausable} from "./interfaces/IPausable.sol";
 import {IProtocolUpgradeHandler} from "./interfaces/IProtocolUpgradeHandler.sol";
+import {Initializable} from "@openzeppelin/contracts/proxy/utils/Initializable.sol";
 
 /// @title Protocol Upgrade Handler
 /// @author Matter Labs
@@ -29,7 +30,7 @@ import {IProtocolUpgradeHandler} from "./interfaces/IProtocolUpgradeHandler.sol"
 ///
 /// The contract implements the state machine that represents the logic of moving upgrade from each
 /// stage by time changes and Guardians/Security Council actions.
-contract ProtocolUpgradeHandler is IProtocolUpgradeHandler {
+contract ProtocolUpgradeHandler is IProtocolUpgradeHandler, Initializable {
     /// @dev Duration of the standard legal veto period.
     /// Note: this value should not exceed EXTENDED_LEGAL_VETO_PERIOD.
     function STANDARD_LEGAL_VETO_PERIOD() internal pure virtual returns (uint256) {
@@ -472,4 +473,23 @@ contract ProtocolUpgradeHandler is IProtocolUpgradeHandler {
 
     /// @dev Contract might receive/hold ETH as part of the maintenance process.
     receive() external payable {}
+
+    /*//////////////////////////////////////////////////////////////
+                        PROXY INITIALIZER
+    //////////////////////////////////////////////////////////////*/
+    function initialize(
+        address _securityCouncil,
+        address _guardians,
+        address _emergencyUpgradeBoard
+    ) external initializer() {
+        securityCouncil = _securityCouncil;
+        emit ChangeSecurityCouncil(address(0), _securityCouncil);
+
+        guardians = _guardians;
+        emit ChangeGuardians(address(0), _guardians);
+
+        emergencyUpgradeBoard = _emergencyUpgradeBoard;
+        emit ChangeEmergencyUpgradeBoard(address(0), _emergencyUpgradeBoard);
+
+    }
 }

--- a/l1-contracts/src/ProtocolUpgradeHandler.sol
+++ b/l1-contracts/src/ProtocolUpgradeHandler.sol
@@ -6,7 +6,7 @@ import {IZKsyncEra} from "./interfaces/IZKsyncEra.sol";
 import {IStateTransitionManager} from "./interfaces/IStateTransitionManager.sol";
 import {IPausable} from "./interfaces/IPausable.sol";
 import {IProtocolUpgradeHandler} from "./interfaces/IProtocolUpgradeHandler.sol";
-import {Initializable} from "@openzeppelin/contracts/proxy/utils/Initializable.sol";
+import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 
 /// @title Protocol Upgrade Handler
 /// @author Matter Labs

--- a/l1-contracts/src/TestnetProtocolUpgradeHandler.sol
+++ b/l1-contracts/src/TestnetProtocolUpgradeHandler.sol
@@ -16,14 +16,18 @@ contract TestnetProtocolUpgradeHandler is ProtocolUpgradeHandler {
         return 0 days;
     }
 
+    /// @dev Duration of the standard ugprade delay period.
+    function UPGRADE_DELAY_PERIOD() internal pure override returns (uint256) {
+        return 0 days;
+    }
+
     /// @notice Initializes the contract with the Security Council address, guardians address and address of L2 voting governor.
-    /// @param _securityCouncil The address to be assigned as the Security Council of the contract.
-    /// @param _guardians The address to be assigned as the guardians of the contract.
     /// @param _l2ProtocolGovernor The address of the L2 voting governor contract for protocol upgrades.
+    /// @param _ZKsyncEra The address of the zkSync Era chain, on top of which the `_l2ProtocolGovernor` is deployed.
+    /// @param _stateTransitionManager The address of the state transition manager.
+    /// @param _bridgeHub The address of the bridgehub.
+    /// @param _sharedBridge The address of the shared bridge.
     constructor(
-        address _securityCouncil,
-        address _guardians,
-        address _emergencyUpgradeBoard,
         address _l2ProtocolGovernor,
         IZKsyncEra _ZKsyncEra,
         IStateTransitionManager _stateTransitionManager,
@@ -31,9 +35,6 @@ contract TestnetProtocolUpgradeHandler is ProtocolUpgradeHandler {
         IPausable _sharedBridge
     )
         ProtocolUpgradeHandler(
-            _securityCouncil,
-            _guardians,
-            _emergencyUpgradeBoard,
             _l2ProtocolGovernor,
             _ZKsyncEra,
             _stateTransitionManager,

--- a/l1-contracts/test/MainnetRedeployForkTest.t.sol
+++ b/l1-contracts/test/MainnetRedeployForkTest.t.sol
@@ -2,7 +2,7 @@
 
 pragma solidity 0.8.24;
 
-import {Test, stdStorage, StdStorage} from "forge-std/Test.sol";
+import {Test, stdStorage, StdStorage, Vm} from "forge-std/Test.sol";
 
 import {Callee} from "./utils/Callee.t.sol";
 import {EmptyContract} from "./utils/EmptyContract.t.sol";
@@ -15,9 +15,74 @@ import {IPausable} from "../../src/interfaces/IPausable.sol";
 
 import {ProtocolUpgradeHandler} from "../../src/ProtocolUpgradeHandler.sol";
 
+
+import {MainnetRedeploy} from "../scripts/MainnetRedeploy.s.sol";
+
+import {DeployedContracts} from "../scripts/Redeploy.s.sol";
+
+import {ITransparentUpgradeableProxy} from "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
+import {ProxyAdmin} from "@openzeppelin/contracts/proxy/transparent/ProxyAdmin.sol";
+
+
 // This test is focused to ensure that the new Proxy-based setup works correctly
 contract MainnetRedeployForkTest is Test {
     using stdStorage for StdStorage;
 
+    MainnetRedeploy script;
+    DeployedContracts addresses;
 
+    modifier onlyMainnet {
+        if (block.chainid == 1) {
+            _;
+        } else {
+            return;
+        }
+    }
+
+    function setUp() external onlyMainnet {
+        if (block.chainid != 1) {
+            return;
+        }
+
+        Vm.Wallet memory deployerWallet = vm.createWallet("deployerWalelt");
+
+        vm.setEnv("PRIVATE_KEY", vm.toString(deployerWallet.privateKey));
+        vm.setEnv("L2_PROTOCOL_GOVERNOR", vm.toString(address(uint160(1))));
+
+        MainnetRedeploy script = new MainnetRedeploy();
+        script.run();
+
+        addresses = script.getDeployedAddresses();
+    }
+
+    function emergencyUpgradeCall(address _to, bytes memory _data) internal {
+        IProtocolUpgradeHandler.Call[] memory calls = new IProtocolUpgradeHandler.Call[](1);
+        calls[0] = IProtocolUpgradeHandler.Call({
+            target: _to,
+            value: 0,
+            data: _data
+        });
+
+        IProtocolUpgradeHandler.UpgradeProposal memory proposal = IProtocolUpgradeHandler.UpgradeProposal({
+            calls: calls,
+            executor: addresses.emergencyUpgradeBoard,
+            salt: bytes32(0)
+        });
+
+        vm.broadcast(addresses.emergencyUpgradeBoard);
+        ProtocolUpgradeHandler(payable(addresses.protocolUpgradeHandlerProxy)).executeEmergencyUpgrade(proposal);
+    }
+
+    // Tests that the new ProtocolUpgradeHandler can upgrade itself
+    function test_MainnetForkProxyUpgrade() external onlyMainnet {
+        address proxyAdmin = address(uint160(uint256(vm.load(addresses.protocolUpgradeHandlerProxy, bytes32(0xb53127684a568b3173ae13b9f8a6016e243e63b6e8ee1178d6a717850b5d6103)))));
+
+        // We upgrade to an incorrect address (guradians), we just test that we can upgrade to a different impl.
+        emergencyUpgradeCall(proxyAdmin, abi.encodeCall(ProxyAdmin.upgradeAndCall, (ITransparentUpgradeableProxy(addresses.protocolUpgradeHandlerProxy), addresses.guardians, hex"")));
+    }
+
+    // Ensures that the new ProtocolUpgradeHandler can call itself
+    function test_MainnetForkSelfCall() external onlyMainnet {
+        emergencyUpgradeCall(addresses.protocolUpgradeHandlerProxy, abi.encodeCall(ProtocolUpgradeHandler.updateSecurityCouncil, (address(uint160(1)))));
+    }
 }

--- a/l1-contracts/test/MainnetRedeployForkTest.t.sol
+++ b/l1-contracts/test/MainnetRedeployForkTest.t.sol
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.8.24;
+
+import {Test, stdStorage, StdStorage} from "forge-std/Test.sol";
+
+import {Callee} from "./utils/Callee.t.sol";
+import {EmptyContract} from "./utils/EmptyContract.t.sol";
+import {StateTransitionManagerMock} from "./mocks/StateTransitionManagerMock.t.sol";
+
+import {IProtocolUpgradeHandler} from "../../src/interfaces/IProtocolUpgradeHandler.sol";
+import {IZKsyncEra} from "../../src/interfaces/IZKsyncEra.sol";
+import {IStateTransitionManager} from "../../src/interfaces/IStateTransitionManager.sol";
+import {IPausable} from "../../src/interfaces/IPausable.sol";
+
+import {ProtocolUpgradeHandler} from "../../src/ProtocolUpgradeHandler.sol";
+
+// This test is focused to ensure that the new Proxy-based setup works correctly
+contract MainnetRedeployForkTest is Test {
+    using stdStorage for StdStorage;
+
+
+}


### PR DESCRIPTION
- Make ProtocolUpgradeHandler deployed as a Proxy.
- Script to re-initialize the system with the same params + test that the upgradeability can work afterward (it is a fork test)