### PR TITLE
feat: Simple Stage 1 

### DIFF
--- a/l1-contracts/src/ProtocolUpgradeHandler.sol
+++ b/l1-contracts/src/ProtocolUpgradeHandler.sol
@@ -46,7 +46,7 @@ contract ProtocolUpgradeHandler is IProtocolUpgradeHandler, Initializable {
     /// This period is intended to provide a buffer after an upgrade's final approval and before its execution,
     /// allowing for final reviews and preparations for devs and users.
     function UPGRADE_DELAY_PERIOD() internal pure virtual returns (uint256) {
-        return 8 days;
+        return 5 days;
     }
 
     /// @dev Time limit for an upgrade proposal to be approved by guardians or expire, and the waiting period for execution post-guardians approval.

--- a/l1-contracts/src/ProtocolUpgradeHandler.sol
+++ b/l1-contracts/src/ProtocolUpgradeHandler.sol
@@ -46,7 +46,7 @@ contract ProtocolUpgradeHandler is IProtocolUpgradeHandler, Initializable {
     /// This period is intended to provide a buffer after an upgrade's final approval and before its execution,
     /// allowing for final reviews and preparations for devs and users.
     function UPGRADE_DELAY_PERIOD() internal pure virtual returns (uint256) {
-        return 1 days;
+        return 8 days;
     }
 
     /// @dev Time limit for an upgrade proposal to be approved by guardians or expire, and the waiting period for execution post-guardians approval.

--- a/l1-contracts/src/ProtocolUpgradeHandler.sol
+++ b/l1-contracts/src/ProtocolUpgradeHandler.sol
@@ -46,7 +46,7 @@ contract ProtocolUpgradeHandler is IProtocolUpgradeHandler, Initializable {
     /// This period is intended to provide a buffer after an upgrade's final approval and before its execution,
     /// allowing for final reviews and preparations for devs and users.
     function UPGRADE_DELAY_PERIOD() internal pure virtual returns (uint256) {
-        return 5 days;
+        return 9 days;
     }
 
     /// @dev Time limit for an upgrade proposal to be approved by guardians or expire, and the waiting period for execution post-guardians approval.

--- a/l1-contracts/test/ProtocolUpgradeHandler.t.sol
+++ b/l1-contracts/test/ProtocolUpgradeHandler.t.sol
@@ -145,8 +145,8 @@ contract TestProtocolUpgradeHandler is Test {
         } else {
             vm.warp(block.timestamp + 30 days);
         }
-        uint256 delayAfterApprove = bound(_delayAfterApprove, 1, type(uint256).max - block.timestamp - 8 days);
-        vm.warp(block.timestamp + 8 days + delayAfterApprove);
+        uint256 delayAfterApprove = bound(_delayAfterApprove, 1, type(uint256).max - block.timestamp - 5 days);
+        vm.warp(block.timestamp + 5 days + delayAfterApprove);
     }
 
     constructor() {
@@ -405,7 +405,7 @@ contract TestProtocolUpgradeHandler is Test {
         _passLegalVeto(_extendedLegalPeriod, id);
         vm.prank(securityCouncil);
         handler.approveUpgradeSecurityCouncil(id);
-        vm.warp(block.timestamp + 8 days);
+        vm.warp(block.timestamp + 5 days);
         assertEq(uint8(handler.upgradeState(id)), uint8(IProtocolUpgradeHandler.UpgradeState.Ready));
     }
 
@@ -469,7 +469,7 @@ contract TestProtocolUpgradeHandler is Test {
         vm.warp(block.timestamp + 30 days);
         assertEq(uint8(handler.upgradeState(id)), uint8(IProtocolUpgradeHandler.UpgradeState.ExecutionPending));
 
-        vm.warp(block.timestamp + 8 days);
+        vm.warp(block.timestamp + 5 days);
         assertEq(uint8(handler.upgradeState(id)), uint8(IProtocolUpgradeHandler.UpgradeState.Ready));
     }
 
@@ -489,7 +489,7 @@ contract TestProtocolUpgradeHandler is Test {
 
         // Now, it should work fine.
 
-        vm.warp(block.timestamp + 8 days);
+        vm.warp(block.timestamp + 5 days);
 
         vm.expectEmit(true, false, false, true);
         emit IProtocolUpgradeHandler.UpgradeExecuted(id);

--- a/l1-contracts/test/ProtocolUpgradeHandler.t.sol
+++ b/l1-contracts/test/ProtocolUpgradeHandler.t.sol
@@ -145,8 +145,8 @@ contract TestProtocolUpgradeHandler is Test {
         } else {
             vm.warp(block.timestamp + 30 days);
         }
-        uint256 delayAfterApprove = bound(_delayAfterApprove, 1, type(uint256).max - block.timestamp - 5 days);
-        vm.warp(block.timestamp + 5 days + delayAfterApprove);
+        uint256 delayAfterApprove = bound(_delayAfterApprove, 1, type(uint256).max - block.timestamp - 9 days);
+        vm.warp(block.timestamp + 9 days + delayAfterApprove);
     }
 
     constructor() {
@@ -405,7 +405,7 @@ contract TestProtocolUpgradeHandler is Test {
         _passLegalVeto(_extendedLegalPeriod, id);
         vm.prank(securityCouncil);
         handler.approveUpgradeSecurityCouncil(id);
-        vm.warp(block.timestamp + 5 days);
+        vm.warp(block.timestamp + 9 days);
         assertEq(uint8(handler.upgradeState(id)), uint8(IProtocolUpgradeHandler.UpgradeState.Ready));
     }
 
@@ -469,7 +469,7 @@ contract TestProtocolUpgradeHandler is Test {
         vm.warp(block.timestamp + 30 days);
         assertEq(uint8(handler.upgradeState(id)), uint8(IProtocolUpgradeHandler.UpgradeState.ExecutionPending));
 
-        vm.warp(block.timestamp + 5 days);
+        vm.warp(block.timestamp + 9 days);
         assertEq(uint8(handler.upgradeState(id)), uint8(IProtocolUpgradeHandler.UpgradeState.Ready));
     }
 
@@ -489,7 +489,7 @@ contract TestProtocolUpgradeHandler is Test {
 
         // Now, it should work fine.
 
-        vm.warp(block.timestamp + 5 days);
+        vm.warp(block.timestamp + 9 days);
 
         vm.expectEmit(true, false, false, true);
         emit IProtocolUpgradeHandler.UpgradeExecuted(id);

--- a/l1-contracts/test/ProtocolUpgradeHandler.t.sol
+++ b/l1-contracts/test/ProtocolUpgradeHandler.t.sol
@@ -145,8 +145,8 @@ contract TestProtocolUpgradeHandler is Test {
         } else {
             vm.warp(block.timestamp + 30 days);
         }
-        uint256 delayAfterApprove = bound(_delayAfterApprove, 1, type(uint256).max - block.timestamp - 1 days);
-        vm.warp(block.timestamp + 1 days + delayAfterApprove);
+        uint256 delayAfterApprove = bound(_delayAfterApprove, 1, type(uint256).max - block.timestamp - 8 days);
+        vm.warp(block.timestamp + 8 days + delayAfterApprove);
     }
 
     constructor() {
@@ -405,7 +405,7 @@ contract TestProtocolUpgradeHandler is Test {
         _passLegalVeto(_extendedLegalPeriod, id);
         vm.prank(securityCouncil);
         handler.approveUpgradeSecurityCouncil(id);
-        vm.warp(block.timestamp + 1 days);
+        vm.warp(block.timestamp + 8 days);
         assertEq(uint8(handler.upgradeState(id)), uint8(IProtocolUpgradeHandler.UpgradeState.Ready));
     }
 
@@ -469,7 +469,7 @@ contract TestProtocolUpgradeHandler is Test {
         vm.warp(block.timestamp + 30 days);
         assertEq(uint8(handler.upgradeState(id)), uint8(IProtocolUpgradeHandler.UpgradeState.ExecutionPending));
 
-        vm.warp(block.timestamp + 1 days);
+        vm.warp(block.timestamp + 8 days);
         assertEq(uint8(handler.upgradeState(id)), uint8(IProtocolUpgradeHandler.UpgradeState.Ready));
     }
 
@@ -489,7 +489,7 @@ contract TestProtocolUpgradeHandler is Test {
 
         // Now, it should work fine.
 
-        vm.warp(block.timestamp + 1 days);
+        vm.warp(block.timestamp + 8 days);
 
         vm.expectEmit(true, false, false, true);
         emit IProtocolUpgradeHandler.UpgradeExecuted(id);


### PR DESCRIPTION
<img width="359" height="229" alt="image" src="https://github.com/user-attachments/assets/8a8d0198-4ad1-4203-88cb-8fac12466398" />

One of the main requirements for Stage 1 is exit window greater or equal than 7 days. The exit window is the time user have to exit the chain after the upgrade is proposed. Current exit window for Era is 4 days: 3 days standard legal veto period + 1 day upgrade delay period. Changing it to 8 days by increasing the upgrade delay period by 4 days. 

Please note, the actual exit window is smaller than 8 days, because the minority of security council can freeze all contracts for 12 hours, and so the real exit window will be 7 days and 12 hours. These 12 hours are added just in case, but theoretically we can reduce upgrade delay period by 12 hours and still be eligible for Stage 1 badge. 



