### PR TITLE
ci: add manual workflow_dispatch to regenerate AllContractsHashes.json

### DIFF
--- a/.github/workflows/regenerate-hashes.yml
+++ b/.github/workflows/regenerate-hashes.yml
@@ -6,14 +6,19 @@ name: Regenerate AllContractsHashes
 # so maintainers can refresh after a foundry version bump, dependency
 # update, or whenever the `hashes` check on a feature branch fails.
 #
-# IMPORTANT: this workflow only lives on `master` for UI visibility. The
-# actual `package.json` + `scripts/calculate-hashes.ts` + AllContractsHashes.json
-# live on the feature branch the run targets — pick that branch in the
-# "Use workflow from" dropdown when triggering, and `actions/checkout`
-# below picks up its tree. Running this against `master` itself will
-# fail at the `yarn install` step (no `package.json` there).
+# This workflow file only lives on `master` (where Actions' "Run workflow"
+# UI is rendered from). The actual `package.json` + `scripts/calculate-hashes.ts`
+# + `AllContractsHashes.json` live on the feature branch passed via the
+# `target_ref` input — `actions/checkout` below picks up that branch's
+# tree, runs the regen against it, and opens the resulting PR back into
+# the same branch.
 on:
   workflow_dispatch:
+    inputs:
+      target_ref:
+        description: "Branch to regenerate AllContractsHashes.json on (e.g. kl/v31-puh-guardians-redeploy)"
+        required: true
+        type: string
 
 jobs:
   regenerate:
@@ -24,6 +29,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
+          ref: ${{ inputs.target_ref }}
           submodules: true
           fetch-depth: 1
 
@@ -51,13 +57,13 @@ jobs:
           title: "chore: regenerate AllContractsHashes.json"
           body: |
             Automated refresh of `AllContractsHashes.json` triggered from
-            the Actions tab against `${{ github.ref_name }}`.
+            the Actions tab against `${{ inputs.target_ref }}`.
 
             Run `yarn calculate-hashes:check` locally on this branch to
             confirm the same diff before merging.
           # Target the branch we ran against, not master (which doesn't
           # have the calculate-hashes script).
-          base: ${{ github.ref_name }}
-          branch: automation/regenerate-hashes-${{ github.ref_name }}
+          base: ${{ inputs.target_ref }}
+          branch: automation/regenerate-hashes-${{ inputs.target_ref }}
           delete-branch: true
           add-paths: AllContractsHashes.json

--- a/.github/workflows/regenerate-hashes.yml
+++ b/.github/workflows/regenerate-hashes.yml
@@ -1,0 +1,63 @@
+name: Regenerate AllContractsHashes
+
+# Rebuild both projects from source, recompute every contract's bytecode
+# hash, and — if AllContractsHashes.json has drifted — open a PR with the
+# refreshed snapshot. Manual trigger only (Actions tab → "Run workflow")
+# so maintainers can refresh after a foundry version bump, dependency
+# update, or whenever the `hashes` check on a feature branch fails.
+#
+# IMPORTANT: this workflow only lives on `master` for UI visibility. The
+# actual `package.json` + `scripts/calculate-hashes.ts` + AllContractsHashes.json
+# live on the feature branch the run targets — pick that branch in the
+# "Use workflow from" dropdown when triggering, and `actions/checkout`
+# below picks up its tree. Running this against `master` itself will
+# fail at the `yarn install` step (no `package.json` there).
+on:
+  workflow_dispatch:
+
+jobs:
+  regenerate:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: true
+          fetch-depth: 1
+
+      - name: Install Foundry
+        uses: dutterbutter/foundry-zksync-toolchain@v1
+
+      - name: Install l1-contracts deps + build (EVM)
+        working-directory: ./l1-contracts
+        run: forge install && forge build
+
+      - name: Install l2-contracts deps + build (EVM + zkSync)
+        working-directory: ./l2-contracts
+        run: forge install && npm install && npm run compile
+
+      - name: Install root deps
+        run: yarn install --frozen-lockfile
+
+      - name: Regenerate AllContractsHashes.json
+        run: yarn calculate-hashes:fix
+
+      - name: Open PR with refreshed hashes
+        uses: peter-evans/create-pull-request@v6
+        with:
+          commit-message: "chore: regenerate AllContractsHashes.json"
+          title: "chore: regenerate AllContractsHashes.json"
+          body: |
+            Automated refresh of `AllContractsHashes.json` triggered from
+            the Actions tab against `${{ github.ref_name }}`.
+
+            Run `yarn calculate-hashes:check` locally on this branch to
+            confirm the same diff before merging.
+          # Target the branch we ran against, not master (which doesn't
+          # have the calculate-hashes script).
+          base: ${{ github.ref_name }}
+          branch: automation/regenerate-hashes-${{ github.ref_name }}
+          delete-branch: true
+          add-paths: AllContractsHashes.json

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.DS_Store
+node_modules/


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/regenerate-hashes.yml` — a `workflow_dispatch`-only workflow that lets maintainers trigger a regeneration of `AllContractsHashes.json` from the Actions tab UI.
- The workflow file lives on `master` purely so the "Run workflow" dropdown appears (GitHub's `workflow_dispatch` UI requires the file to be on the default branch). The dropdown lets you pick which feature branch to actually run against; `actions/checkout` picks up that branch's tree, runs `yarn calculate-hashes:fix`, and opens a PR targeting the same branch.
- Master itself doesn't carry `package.json` / `scripts/calculate-hashes.ts` / `AllContractsHashes.json` — those live on the feature branches that introduce them (`kl/v31-puh-guardians-redeploy` at the moment). Running this workflow against `master` will therefore fail at `yarn install` — that's intentional.

## Test plan
- [ ] Merge this PR.
- [ ] Go to Actions tab → "Regenerate AllContractsHashes" → Run workflow → pick `kl/v31-puh-guardians-redeploy` from the dropdown.
- [ ] Confirm: a PR is opened on `automation/regenerate-hashes-kl/v31-puh-guardians-redeploy` targeting `kl/v31-puh-guardians-redeploy`, either no-op (snapshot already current) or with the freshly regenerated `AllContractsHashes.json` diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)