### PR TITLE
lint: fix scopelint v0.1.0 errors flagged on master

### DIFF
--- a/l2-contracts/src/ZkTokenV1.sol
+++ b/l2-contracts/src/ZkTokenV1.sol
@@ -3,7 +3,6 @@ pragma solidity 0.8.24;
 
 import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 import {SafeCastUpgradeable} from "@openzeppelin/contracts-upgradeable/utils/math/SafeCastUpgradeable.sol";
-import {ERC20Upgradeable} from "@openzeppelin/contracts-upgradeable/token/ERC20/ERC20Upgradeable.sol";
 import {ERC20VotesUpgradeable} from
   "@openzeppelin/contracts-upgradeable/token/ERC20/extensions/ERC20VotesUpgradeable.sol";
 import {AccessControlUpgradeable} from "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol";
@@ -110,8 +109,9 @@ contract ZkTokenV1 is Initializable, ERC20VotesUpgradeable, AccessControlUpgrade
     if (block.timestamp > _expiry) {
       revert DelegateSignatureExpired(_expiry);
     }
+    uint256 _nonce = _useNonce(_signer);
     bool _isSignatureValid = _signer.isValidSignatureNow(
-      _hashTypedDataV4(keccak256(abi.encode(DELEGATION_TYPEHASH, _signer, _delegatee, _useNonce(_signer), _expiry))),
+      _hashTypedDataV4(keccak256(abi.encode(DELEGATION_TYPEHASH, _signer, _delegatee, _nonce, _expiry))),
       _signature
     );
 

--- a/l2-contracts/test/GovernorSettableFixedQuorum.t.sol
+++ b/l2-contracts/test/GovernorSettableFixedQuorum.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.24;
 
-import {Test, console2} from "forge-std/Test.sol";
+import {Test} from "forge-std/Test.sol";
 import {GovernorSettableFixedQuorum} from "src/extensions/GovernorSettableFixedQuorum.sol";
 import {ZkProtocolGovernorHarness} from "test/harnesses/ZkProtocolGovernorHarness.sol";
 import {ProposalTest} from "test/helpers/ProposalTest.sol";

--- a/l2-contracts/test/ZkCappedMinter.t.sol
+++ b/l2-contracts/test/ZkCappedMinter.t.sol
@@ -4,7 +4,6 @@ pragma solidity 0.8.24;
 import {ZkTokenTest} from "test/utils/ZkTokenTest.sol";
 import {IMintableAndDelegatable} from "src/interfaces/IMintableAndDelegatable.sol";
 import {ZkCappedMinter} from "src/ZkCappedMinter.sol";
-import {console2} from "forge-std/Test.sol";
 
 contract ZkCappedMinterTest is ZkTokenTest {
   function setUp() public virtual override {

--- a/l2-contracts/test/ZkCappedMinterFactory.t.sol
+++ b/l2-contracts/test/ZkCappedMinterFactory.t.sol
@@ -5,8 +5,6 @@ import {ZkTokenTest} from "test/utils/ZkTokenTest.sol";
 import {ZkCappedMinterFactory} from "src/ZkCappedMinterFactory.sol";
 import {ZkCappedMinter} from "src/ZkCappedMinter.sol";
 import {IMintableAndDelegatable} from "src/interfaces/IMintableAndDelegatable.sol";
-import {Create2} from "@openzeppelin/contracts/utils/Create2.sol";
-import {console2} from "forge-std/console2.sol";
 import {stdJson} from "forge-std/StdJson.sol";
 
 contract ZkCappedMinterFactoryTest is ZkTokenTest {

--- a/l2-contracts/test/ZkCappedMinterV2.t.sol
+++ b/l2-contracts/test/ZkCappedMinterV2.t.sol
@@ -5,7 +5,6 @@ import {ZkTokenTest} from "test/utils/ZkTokenTest.sol";
 import {Strings} from "@openzeppelin/contracts/utils/Strings.sol";
 import {IMintable} from "src/interfaces/IMintable.sol";
 import {ZkCappedMinterV2} from "src/ZkCappedMinterV2.sol";
-import {console2} from "forge-std/Test.sol";
 
 contract ZkCappedMinterV2Test is ZkTokenTest {
   ZkCappedMinterV2 public cappedMinter;

--- a/l2-contracts/test/ZkCappedMinterV2Factory.t.sol
+++ b/l2-contracts/test/ZkCappedMinterV2Factory.t.sol
@@ -5,8 +5,6 @@ import {ZkTokenTest} from "test/utils/ZkTokenTest.sol";
 import {ZkCappedMinterV2Factory} from "src/ZkCappedMinterV2Factory.sol";
 import {ZkCappedMinterV2} from "src/ZkCappedMinterV2.sol";
 import {IMintable} from "src/interfaces/IMintable.sol";
-import {Create2} from "@openzeppelin/contracts/utils/Create2.sol";
-import {console2} from "forge-std/console2.sol";
 import {stdJson} from "forge-std/StdJson.sol";
 
 contract ZkCappedMinterV2FactoryTest is ZkTokenTest {

--- a/l2-contracts/test/ZkGovOpsGovernor.t.sol
+++ b/l2-contracts/test/ZkGovOpsGovernor.t.sol
@@ -2,7 +2,7 @@
 pragma solidity 0.8.24;
 
 import {IGovernor} from "@openzeppelin/contracts/governance/IGovernor.sol";
-import {Test, console2} from "forge-std/Test.sol";
+import {Test} from "forge-std/Test.sol";
 
 import {ZkGovOpsGovernor} from "src/ZkGovOpsGovernor.sol";
 import {GovernorGuardianVeto} from "src/extensions/GovernorGuardianVeto.sol";

--- a/l2-contracts/test/ZkMerkleDistributor.t.sol
+++ b/l2-contracts/test/ZkMerkleDistributor.t.sol
@@ -5,12 +5,10 @@ import {ZkTokenTest} from "test/utils/ZkTokenTest.sol";
 import {IMintableAndDelegatable} from "src/interfaces/IMintableAndDelegatable.sol";
 import {ZkMerkleDistributor} from "src/ZkMerkleDistributor.sol";
 import {Merkle} from "@murky/src/Merkle.sol";
-import {console2, stdStorage, StdStorage} from "forge-std/Test.sol";
+import {stdStorage, StdStorage} from "forge-std/Test.sol";
 
 contract ZkMerkleDistributorTest is ZkTokenTest {
   Merkle merkle;
-
-  error ZkMerkleDistributor__InvalidProof();
 
   /// @notice Type hash of the data that makes up the claim request.
   bytes32 public constant ZK_CLAIM_TYPEHASH =

--- a/l2-contracts/test/ZkProtocolGovernor.integration.t.sol
+++ b/l2-contracts/test/ZkProtocolGovernor.integration.t.sol
@@ -1,10 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.24;
 
-import {console2} from "forge-std/Test.sol";
 import {TimelockController} from "@openzeppelin/contracts/governance/TimelockController.sol";
 import {IVotes} from "@openzeppelin/contracts/governance/utils/IVotes.sol";
-import {ProxyAdmin} from "@openzeppelin/contracts/proxy/transparent/ProxyAdmin.sol";
 import {ITransparentUpgradeableProxy} from "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
 import {ProposalBuilder} from "test/helpers/ProposalBuilder.sol";
 import {IntegrationTest} from "test/helpers/IntegrationTest.sol";

--- a/l2-contracts/test/ZkProtocolGovernor.t.sol
+++ b/l2-contracts/test/ZkProtocolGovernor.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.24;
 
-import {Test, console2} from "forge-std/Test.sol";
+import {Test} from "forge-std/Test.sol";
 import {TimelockController} from "@openzeppelin/contracts/governance/TimelockController.sol";
 import {IVotes} from "@openzeppelin/contracts/governance/utils/IVotes.sol";
 import {ZkProtocolGovernor} from "src/ZkProtocolGovernor.sol";

--- a/l2-contracts/test/ZkTokenGovernor.t.sol
+++ b/l2-contracts/test/ZkTokenGovernor.t.sol
@@ -2,7 +2,7 @@
 pragma solidity 0.8.24;
 
 import {IGovernor} from "@openzeppelin/contracts/governance/IGovernor.sol";
-import {Test, console2} from "forge-std/Test.sol";
+import {Test} from "forge-std/Test.sol";
 import {ProposalTest} from "test/helpers/ProposalTest.sol";
 
 import {ZkTokenGovernor} from "src/ZkTokenGovernor.sol";

--- a/l2-contracts/test/ZkTokenV2.t.sol
+++ b/l2-contracts/test/ZkTokenV2.t.sol
@@ -4,7 +4,6 @@ pragma solidity 0.8.24;
 import {Test} from "forge-std/Test.sol";
 import {ZkTokenV1} from "src/ZkTokenV1.sol";
 import {ZkTokenV2} from "src/ZkTokenV2.sol";
-import {IERC1271} from "@openzeppelin/contracts/interfaces/IERC1271.sol";
 import {
   TransparentUpgradeableProxy,
   ITransparentUpgradeableProxy

--- a/l2-contracts/test/fakes/ERC20VotesFake.sol
+++ b/l2-contracts/test/fakes/ERC20VotesFake.sol
@@ -3,7 +3,6 @@ pragma solidity 0.8.24;
 
 import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import {ERC20Votes} from "@openzeppelin/contracts/token/ERC20/extensions/ERC20Votes.sol";
-import {IVotes} from "@openzeppelin/contracts/governance/utils/IVotes.sol";
 import {ERC20Permit} from "@openzeppelin/contracts/token/ERC20/extensions/ERC20Permit.sol";
 import {SafeCast} from "@openzeppelin/contracts/utils/math/SafeCast.sol";
 

--- a/l2-contracts/test/helpers/IntegrationTest.sol
+++ b/l2-contracts/test/helpers/IntegrationTest.sol
@@ -7,7 +7,6 @@ import {ProposalBuilder} from "test/helpers/ProposalBuilder.sol";
 import {IVotes} from "@openzeppelin/contracts/governance/utils/IVotes.sol";
 import {IAccessControl} from "@openzeppelin/contracts/access/IAccessControl.sol";
 import {TimelockController} from "@openzeppelin/contracts/governance/TimelockController.sol";
-import {IGovernor} from "@openzeppelin/contracts/governance/IGovernor.sol";
 import {IGovernorTimelock} from "@openzeppelin/contracts/governance/extensions/IGovernorTimelock.sol";
 
 interface ERC20VotesMintable is IVotes, IAccessControl {

--- a/l2-contracts/test/utils/ZkTokenTest.sol
+++ b/l2-contracts/test/utils/ZkTokenTest.sol
@@ -1,9 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.24;
 
-import {Test, console2} from "forge-std/Test.sol";
+import {Test} from "forge-std/Test.sol";
 import {ZkTokenV1} from "src/ZkTokenV1.sol";
-import {IMintableAndDelegatable} from "src/interfaces/IMintableAndDelegatable.sol";
 
 contract ZkTokenTest is Test {
   ZkTokenV1 token;


### PR DESCRIPTION
## Summary
`scopelint` v0.1.0 (current `latest`, released 2026-02-24) added new convention checks that flag code merged on master from PRs that were green at the time. Without these fixes, every PR branched off current master fails CI's lint job.

- Remove unused imports across 14 test files: `console2`, `Create2`, `IGovernor`, `IERC1271`, `IVotes`, `ProxyAdmin`, `ERC20Upgradeable`, `IMintableAndDelegatable`.
- Delete the dead local \`error ZkMerkleDistributor__InvalidProof\` declaration in \`ZkMerkleDistributor.t.sol\` — never referenced; the two \`vm.expectRevert(...)\` sites use \`ZkMerkleDistributor.<error>.selector\` from the source contract.
- Hoist \`_useNonce(_signer)\` out of the \`abi.encode(...)\` arg list in \`ZkTokenV1.sol#delegateOnBehalf\` into a \`_nonce\` local. Behaviour is identical; scopelint v0.1.0's EIP712 typehash arg-counter mis-counts function-call args, so this satisfies the check without changing the encoded payload.

No `.sol` semantics change. 15 files, +8/-22.

## Test plan
- [ ] CI lint job passes (it was failing on master).
- [ ] CI build + tests still pass (no test logic changed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)