### PR TITLE
ci(v31): regenerate-hashes pushes directly to branch instead of opening a PR

### DIFF
--- a/.github/workflows/regenerate-hashes.yml
+++ b/.github/workflows/regenerate-hashes.yml
@@ -1,10 +1,11 @@
 name: Regenerate AllContractsHashes
 
 # Rebuild both projects from source, recompute every contract's bytecode
-# hash, and — if AllContractsHashes.json has drifted — open a PR with the
-# refreshed snapshot. Manual trigger (Actions tab → "Run workflow") so
-# maintainers can refresh after a foundry version bump, dependency update,
-# or whenever the `hashes` check on the main CI fails.
+# hash, and — if AllContractsHashes.json has drifted — commit the refresh
+# directly to the branch the workflow ran against. Manual trigger
+# (Actions tab → "Run workflow", pick this branch from the dropdown) so
+# maintainers can refresh after a foundry version bump, dependency
+# update, or whenever the `hashes` check fails.
 on:
   workflow_dispatch:
 
@@ -37,17 +38,15 @@ jobs:
       - name: Regenerate AllContractsHashes.json
         run: yarn calculate-hashes:fix
 
-      - name: Open PR with refreshed hashes
-        uses: peter-evans/create-pull-request@v6
-        with:
-          commit-message: "chore: regenerate AllContractsHashes.json"
-          title: "chore: regenerate AllContractsHashes.json"
-          body: |
-            Automated refresh of `AllContractsHashes.json` triggered from
-            the Actions tab.
-
-            Run `yarn calculate-hashes:check` locally on this branch to
-            confirm the same diff before merging.
-          branch: automation/regenerate-hashes
-          delete-branch: true
-          add-paths: AllContractsHashes.json
+      - name: Commit + push refreshed hashes (no-op if unchanged)
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          if [[ -n "$(git status --porcelain AllContractsHashes.json)" ]]; then
+            git add AllContractsHashes.json
+            git commit -m "chore: regenerate AllContractsHashes.json"
+            git push origin HEAD:${{ github.ref_name }}
+            echo "Pushed regen commit to ${{ github.ref_name }}."
+          else
+            echo "AllContractsHashes.json already up to date — nothing to commit."
+          fi


### PR DESCRIPTION
## Summary
For the v31 upgrade ceremony, when a maintainer manually triggers `Regenerate AllContractsHashes` from the Actions tab, land the regen commit directly on \`kl/v31-puh-guardians-redeploy\` instead of opening a side PR back into the branch.

- Replaces the \`peter-evans/create-pull-request@v6\` step with a plain \`git commit + push\` using the \`github-actions[bot]\` identity.
- No-ops cleanly when \`AllContractsHashes.json\` is already up to date (matches the previous PR action's no-op behaviour — log line: \`AllContractsHashes.json already up to date — nothing to commit.\`).
- Pushes to \`\${{ github.ref_name }}\` so this only ever lands on the branch the workflow was triggered against.

## Scope
**This branch only.** \`master\` keeps the PR-opening variant for any other branches that adopt the workflow later. Once the v31 ceremony lands, this delta either gets dropped or up-ported to master per future preference.

## Test plan
- [ ] After merging, trigger \`Regenerate AllContractsHashes\` from the Actions tab with branch \`kl/v31-puh-guardians-redeploy\` selected.
- [ ] If \`AllContractsHashes.json\` was already current: workflow logs \`already up to date — nothing to commit\` and finishes green. No new commit on the branch.
- [ ] If anything has drifted: a \`chore: regenerate AllContractsHashes.json\` commit by \`github-actions[bot]\` lands on the branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)