### PR TITLE
Reduce upgrade execution delay from 9 days to 1 day

### DIFF
--- a/AllContractsHashes.json
+++ b/AllContractsHashes.json
@@ -111,10 +111,10 @@
   },
   {
     "contractName": "l1-contracts/ProtocolUpgradeHandler",
-    "evmBytecodeHash": "0xf96e0759690c6d06a910be9878b80ee612d552a9d2c07a786c8016b4229586f0",
+    "evmBytecodeHash": "0xb5bc389e8c6f92817281f8edaf34efc10a95286cdc22730867e62dd5bef2d0d1",
     "evmBytecodePath": "/l1-contracts/out/ProtocolUpgradeHandler.sol/ProtocolUpgradeHandler.json",
-    "evmDeployedBytecodeHash": "0xe300fbf77eece27a1476aa649dc03ee932ebf0d65c28f1405cfba86d2e65115c",
-    "evmDeployedBytecodeBlakeHash": "0x753bd7ac463a2a8fd64b27cbd7fd8d70c32ef5f02b0039a96efa8a76727e2283",
+    "evmDeployedBytecodeHash": "0x2659c9ceea09bb871d1fbe99ffb373c5f40516a4436d7d8b2a722ba1f3d32071",
+    "evmDeployedBytecodeBlakeHash": "0x9d740efcdeb08084f7b155e54c98445ef1a3078df79b66843c7a0740d5cf3fc4",
     "evmDeployedBytecodeLength": 15911,
     "zkBytecodeHash": null,
     "zkBytecodePath": null
@@ -211,10 +211,10 @@
   },
   {
     "contractName": "l1-contracts/TestnetProtocolUpgradeHandler",
-    "evmBytecodeHash": "0x7d4912bee2122ed67c70ec95fce0dbcc4ed95b0971e1a23672a039d803e6baff",
+    "evmBytecodeHash": "0x19e14c5366023430f0dce0cc10dfaf2765760d8f889371b30891ad3e1f2dcaf2",
     "evmBytecodePath": "/l1-contracts/out/TestnetProtocolUpgradeHandler.sol/TestnetProtocolUpgradeHandler.json",
-    "evmDeployedBytecodeHash": "0x23c4a1b21959e32ea7d593d9a283adc794d10deb5c590c51882fadbeb0e508b6",
-    "evmDeployedBytecodeBlakeHash": "0x766d06e0a99ea05399712aa9af72b511f20fa91fe30861ebec2cfeebeae6fb34",
+    "evmDeployedBytecodeHash": "0xc6f217c64bca859acc3b09573608b3e6f41e1c601eedbc1d2f899368ca8bfeca",
+    "evmDeployedBytecodeBlakeHash": "0xff02e917e0b04e2ce2da868333033fa4cd8fe1ab0d03b65ab244fce5d18e5771",
     "evmDeployedBytecodeLength": 15902,
     "zkBytecodeHash": null,
     "zkBytecodePath": null

--- a/l1-contracts/src/ProtocolUpgradeHandler.sol
+++ b/l1-contracts/src/ProtocolUpgradeHandler.sol
@@ -45,7 +45,7 @@ contract ProtocolUpgradeHandler is IProtocolUpgradeHandler, Initializable {
   /// This period is intended to provide a buffer after an upgrade's final approval and before its execution,
   /// allowing for final reviews and preparations for devs and users.
   function UPGRADE_DELAY_PERIOD() internal pure virtual returns (uint256) {
-    return 9 days;
+    return 1 days;
   }
 
   /// @dev Time limit for an upgrade proposal to be approved by guardians or expire, and the waiting period for

--- a/l1-contracts/test/ProtocolUpgradeHandler.t.sol
+++ b/l1-contracts/test/ProtocolUpgradeHandler.t.sol
@@ -151,8 +151,8 @@ contract TestProtocolUpgradeHandler is Test {
     } else {
       vm.warp(block.timestamp + 30 days);
     }
-    uint256 delayAfterApprove = bound(_delayAfterApprove, 1, type(uint256).max - block.timestamp - 9 days);
-    vm.warp(block.timestamp + 9 days + delayAfterApprove);
+    uint256 delayAfterApprove = bound(_delayAfterApprove, 1, type(uint256).max - block.timestamp - 1 days);
+    vm.warp(block.timestamp + 1 days + delayAfterApprove);
   }
 
   constructor() {
@@ -430,7 +430,7 @@ contract TestProtocolUpgradeHandler is Test {
     _passLegalVeto(_extendedLegalPeriod, id);
     vm.prank(securityCouncil);
     handler.approveUpgradeSecurityCouncil(id);
-    vm.warp(block.timestamp + 9 days);
+    vm.warp(block.timestamp + 1 days);
     assertEq(uint8(handler.upgradeState(id)), uint8(IProtocolUpgradeHandler.UpgradeState.Ready));
   }
 
@@ -494,7 +494,7 @@ contract TestProtocolUpgradeHandler is Test {
     vm.warp(block.timestamp + 30 days);
     assertEq(uint8(handler.upgradeState(id)), uint8(IProtocolUpgradeHandler.UpgradeState.ExecutionPending));
 
-    vm.warp(block.timestamp + 9 days);
+    vm.warp(block.timestamp + 1 days);
     assertEq(uint8(handler.upgradeState(id)), uint8(IProtocolUpgradeHandler.UpgradeState.Ready));
   }
 
@@ -514,7 +514,7 @@ contract TestProtocolUpgradeHandler is Test {
 
     // Now, it should work fine.
 
-    vm.warp(block.timestamp + 9 days);
+    vm.warp(block.timestamp + 1 days);
 
     vm.expectEmit(true, false, false, true);
     emit IProtocolUpgradeHandler.UpgradeExecuted(id);


### PR DESCRIPTION
## What

Reduce the mandatory protocol-upgrade execution delay from **9 days to 1 day**.

This would allow to temporarily remove this delay that is applied to the entire ecosystem until there is an immediate need for stage1 support. It can be added back later on very easily.

## Changes

## Testing

- `forge test` (ci profile, 2500 fuzz runs): **81 passed, 0 failed**.
- `forge fmt --check` on the changed files: clean.
- Bytecode hashes verified deterministic against unchanged contracts before patching `AllContractsHashes.json`; only the two affected entries change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
